### PR TITLE
Fixed invalid converting $id to ":null:" 

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -512,7 +512,7 @@ class Breadcrumbs extends Component
                 );
             }
 
-            if (!is_null($url)) {
+            if (is_null($url)) {
                 $id = ':null:';
             }
 


### PR DESCRIPTION
Fixed invalid converting $id to ":null:" if $url is not null in update function.